### PR TITLE
Support queries in random

### DIFF
--- a/src/api/Cards.ts
+++ b/src/api/Cards.ts
@@ -624,8 +624,8 @@ class Cards extends MagicQuerier {
 		return this.queryCard(["cards/cardmarket", id]);
 	}
 
-	public async random () {
-		return this.queryCard("cards/random");
+	public async random (query?: string) {
+		return this.queryCard("cards/random", { q: query });
 	}
 
 	/**

--- a/src/tests/Main.ts
+++ b/src/tests/Main.ts
@@ -181,6 +181,12 @@ describe("Scry", function () {
 			expect(card).not.eq(undefined);
 		});
 
+		it("random with query", async () => {
+			const card = await Scry.Cards.random("type:planeswalker");
+			expect(card).not.eq(undefined);
+			expect(card.type_line).to.include("Planeswalker")
+		});
+
 		it("autocomplete name", async () => {
 			const cardNames = await Scry.Cards.autoCompleteName("bloodsc");
 			expect(cardNames).include("Blood Scrivener");


### PR DESCRIPTION
Scryfall API allows a query to filter down the results before selecting a random card: https://scryfall.com/docs/api/cards/random